### PR TITLE
Add a column with yearly average rainfall (to be tested)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -135,3 +135,4 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+.vscode/settings.json


### PR DESCRIPTION
A function has been added in the sql script to calculate the yearly average between the current date and 1 year from this current date. 
This function is then used when constructing the table fire_data_with_avg_weather to append a column prcp_avg_year which is the average precipitation over a year. 
This has been tested by small parts, not as a whole => please try and give feedback :) 
ps : one thing to double check is the postgresql function body delimiter. It is supposed to be dollar-quoted string constants ($$), but it depends on the platforms. I had to use single quote (') on my local setup. So maybe the single quote ' should be changed to double dollar $$ (see lines 126 and 136)